### PR TITLE
Adding the (in)obvious step zero

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -4,7 +4,7 @@
 
 Enter the pAI-OS backend source directory:
 
-    cd paios/backed/
+    cd paios/backend/
 
 Create a new python virtual environment (venv) in .venv:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,6 +2,10 @@
 
 ## Setup
 
+Enter the pAI-OS backend source directory:
+
+    cd paios/backed/
+
 Create a new python virtual environment (venv) in .venv:
 
     python3 -m venv .venv


### PR DESCRIPTION
Going from the paios/README.md to paios/backend/README.md the documentation just missed the intuitive move on the CLI. It took me only 30 seconds to figure out what I'd missed, but seems worth adding the step.

Testing these instructions, I do get a running server but not the output example, I'll troubleshoot and ask @samj for guidance if I can't figure it out. It is probably something in my environment? I haven't loaded any test data or etc. so I'm not sure yet where `/user/142` is supposed to be coming from.