### PR TITLE
Suggestion for easier-to-review docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to Kwaai's Personal AI Operating System (pAI-OS)
 
-Thank you for your interest in contributing to pAI-OS! We welcome contributions from the community to help make pAI-OS even better.
+Thank you for your interest in contributing to pAI-OS!
+We welcome contributions from the community to help make pAI-OS even better.
 
 ## Getting Started
 
@@ -17,15 +18,20 @@ To get started with contributing to pAI-OS, please follow these steps:
 
 ## Code Style
 
-We follow a specific code style in the pAI-OS project to ensure consistency and readability. Please make sure to adhere to the following guidelines:
+We follow a specific code style in the pAI-OS project to ensure consistency and readability.
+Please make sure to adhere to the following guidelines:
 
 - Use consistent indentation (e.g., 4 spaces).
 - Follow the naming conventions for variables, functions, and classes.
 - Write clear and concise comments to explain your code.
+- In documentation, put each sentence on its own line and a blank line between one or more sentences for paragraphs.
+  (This helps with the content review process by making clear where changes occur in a paragraph.)
+  
 
 ## Reporting Issues
 
-If you encounter any bugs or issues while using pAI-OS, please report them on the GitHub issue tracker. When reporting an issue, please provide the following information:
+If you encounter any bugs or issues while using pAI-OS, please report them on the GitHub issue tracker.
+When reporting an issue, please provide the following information:
 
 - A clear and concise description of the issue.
 - Steps to reproduce the issue.
@@ -33,11 +39,14 @@ If you encounter any bugs or issues while using pAI-OS, please report them on th
 
 ## Feature Requests
 
-If you have an idea for a new feature or improvement for pAI-OS, we would love to hear it! Please open a GitHub issue and provide a detailed description of your proposed feature.
+If you have an idea for a new feature or improvement for pAI-OS, we would love to hear it!
+Please open a GitHub issue and provide a detailed description of your proposed feature.
 
 ## Code Reviews
 
-All contributions to PapAI-OS go through a code review process. This helps ensure the quality and maintainability of the codebase. Please be open to feedback and make any necessary changes based on the code review comments.
+All contributions to PapAI-OS go through a code review process.
+This helps ensure the quality and maintainability of the codebase.
+Please be open to feedback and make any necessary changes based on the code review comments.
 
 ## License
 By contributing to pAI-OS, you acknowledge that your contributions will be licensed under the [MIT License](https://opensource.org/licenses/MIT) and that you have read and certified the [Developer Certificate of Origin (DCO)](CERTIFICATION.md).


### PR DESCRIPTION
- Including how-to for the idea of having a single-line-per-sentence
- Hopefully the instructions are clear?
- Then I made the suggested changes across the document, which should help demonstrate the (potential) value.
- This practice is _very_ useful when working on longer, denser, and more complex documentation.
- For example, we can use GitHub directly for collaborative reviews of project docs, like we did with the governance file in this project: https://github.com/operate-first/community/commits/main/governance.md
- I'm not sure how common this practice is elsewhere, but we also used it for `theopensourceway` in most of the AsciiDoc files and the PDF is 149 pages all together.