### PR TITLE
CRUD Personas with fixes

### DIFF
--- a/.github/workflows/verify-gpg-signatures.yml
+++ b/.github/workflows/verify-gpg-signatures.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - '**'
-  pull_request:
-    branches:
-      - '**'
   workflow_dispatch:
     inputs:
       check_all_commits:

--- a/README.md
+++ b/README.md
@@ -67,4 +67,3 @@ python -m paios
 
 Visit [http://localhost:3080/](http://localhost:3080/)
 
-

--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ python -m paios
 
 Visit [http://localhost:3080/](http://localhost:3080/)
 
+

--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ python -m paios
 ```
 
 Visit [http://localhost:3080/](http://localhost:3080/)
+

--- a/apis/paios/openapi.yaml
+++ b/apis/paios/openapi.yaml
@@ -549,6 +549,91 @@ paths:
           description: User Not Found
         '409':
           description: Email Already Taken
+  /personas:
+    get:
+      tags:
+        - Persona Management
+      summary: Retrieve all personas
+      description: Get all personas.
+      parameters:
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/range'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Persona'
+          headers:
+            X-Total-Count:
+              $ref: '#/components/headers/X-Total-Count'
+    post:
+      summary: Create new persona
+      tags:
+        - Persona Management
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Persona'
+        '400':
+          description: Missing Required Information
+      description: Creates a new persona.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PersonaCreate'
+  '/personas/{id}':
+    get:
+      tags:
+        - Persona Management
+      summary: Retrieve persona by id
+      description: Retrieve the information of the persona with the matching persona ID.
+      parameters:
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Persona'
+    put:
+      summary: Update persona by id
+      tags:
+        - Persona Management
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Persona'
+      description: Updates the persona with the given id.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Persona'
+    delete:
+      summary: Delete persona by id
+      description: Deletes the persona with the given id.
+      tags:
+        - Persona Management
+      responses:
+        '204':
+          description: No Content
+        '404':
+          description: Not Found
+    parameters:
+      - $ref: '#/components/parameters/id'  
 tags:
   - name: Abilities Management
     description: Installation and configuration of abilities
@@ -562,6 +647,8 @@ tags:
     description: Management of downloads
   - name: User Management
     description: Management of user accounts
+  - name: Persona Management
+    description: Management of personas
 components:
   headers:
     X-Total-Count:
@@ -959,3 +1046,36 @@ components:
       required:
         - name
         - email
+    Persona:
+      type: object
+      title: Persona
+      properties:
+        id:
+          $ref: '#/components/schemas/uuid4ReadOnly'
+        name:
+          $ref: '#/components/schemas/name'
+        description:
+          $ref: '#/components/schemas/textLong'
+        voice_id:
+          $ref: '#/components/schemas/uuid4'
+        face_id:
+          $ref: '#/components/schemas/uuid4'
+      required:
+        - name
+    PersonaCreate:
+      type: object
+      title: PersonaCreate
+      description: Persona without id which is server-generated.
+      properties:
+        id:
+          $ref: '#/components/schemas/uuid4ReadOnly'
+        name:
+          $ref: '#/components/schemas/name'
+        description:
+          $ref: '#/components/schemas/textLong'
+        voice_id:
+          $ref: '#/components/schemas/uuid4'
+        face_id:
+          $ref: '#/components/schemas/uuid4'
+      required:        
+        - name

--- a/apis/paios/personas.http
+++ b/apis/paios/personas.http
@@ -1,0 +1,37 @@
+# API testing with Visual Studio Code - REST Client Extention
+
+POST http://localhost:3080/api/v1/personas
+Authorization: Bearer {{PAIOS_BEARER_TOKEN}}
+Content-Type: application/json
+
+{
+  "name": "Attention Is All You Need",
+  "description": "Ashish Vaswani et al",
+  "voice_id": "Artificial Intelligence",
+  "face_id": "We propose a new simple network architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence and convolutions entirely."
+}
+
+###
+
+PUT http://localhost:3080/api/v1/personas/1cbb0bc5-bae2-4b9d-9555-f2282f767047
+Authorization: Bearer {{PAIOS_BEARER_TOKEN}}
+Content-Type: application/json
+
+{
+  "name": "Generative Adversarial Networks",
+  "description": "Goodfellow et al",
+  "voice_id": "Artificial Intelligence",
+  "face_id": "We propose a new framework for estimating generative models via an adversarial process, in which we simultaneously train two models: a generative model G that captures the data distribution, and a discriminative model D that estimates the probability that a sample came from the training data rather than G."
+}
+
+###
+
+GET http://localhost:3080/api/v1/personas/1cbb0bc5-bae2-4b9d-9555-f2282f767047
+Authorization: Bearer {{PAIOS_BEARER_TOKEN}}
+Content-Type: application/json
+
+###
+
+DELETE http://localhost:3080/api/v1/personas/1cbb0bc5-bae2-4b9d-9555-f2282f767047
+Authorization: Bearer {{PAIOS_BEARER_TOKEN}}
+Content-Type: application/json

--- a/backend/api/PersonasView.py
+++ b/backend/api/PersonasView.py
@@ -1,0 +1,54 @@
+from starlette.responses import JSONResponse, Response
+from backend.managers.PersonasManager import PersonasManager
+from common.paths import api_base_url
+from backend.pagination import parse_pagination_params
+from backend.schemas import PersonaCreateSchema
+
+
+class PersonasView:
+    def __init__(self):
+        self.pm = PersonasManager()
+
+    async def get(self, id: str):
+        persona = await self.pm.retrieve_persona(id)
+        if persona is None:
+            return JSONResponse({"error": "Persona not found"}, status_code=404)
+        return JSONResponse(persona.dict(), status_code=200)
+
+    async def post(self, body: PersonaCreateSchema):
+        id = await self.pm.create_persona(body)
+        persona = await self.pm.retrieve_persona(id)
+        return JSONResponse(persona.dict(), status_code=201, headers={'Location': f'{api_base_url}/personas/{id}'})
+
+    async def put(self, id: str, body: PersonaCreateSchema):
+        await self.pm.update_persona(id, body)
+        persona = await self.pm.retrieve_persona(id)
+        if persona is None:
+            return JSONResponse({"error": "Persona not found"}, status_code=404)
+        return JSONResponse(persona.dict(), status_code=200)
+
+    async def delete(self, id: str):
+        success = await self.pm.delete_persona(id)
+        if not success:
+            return JSONResponse({"error": "Persona not found"}, status_code=404)
+        return Response(status_code=204)
+
+    async def search(self, filter: str = None, range: str = None, sort: str = None):
+        result = parse_pagination_params(filter, range, sort)
+        if isinstance(result, JSONResponse):
+            return result
+
+        offset, limit, sort_by, sort_order, filters = result
+
+        personas, total_count = await self.pm.retrieve_personas(
+            limit=limit,
+            offset=offset,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            filters=filters
+        )
+        headers = {
+            'X-Total-Count': str(total_count),
+            'Content-Range': f'personas {offset}-{offset + len(personas) - 1}/{total_count}'
+        }
+        return JSONResponse([persona.dict() for persona in personas], status_code=200, headers=headers)

--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -6,3 +6,4 @@ from .ChannelsView import ChannelsView
 from .ConfigView import ConfigView
 from .DownloadsView import DownloadsView
 from .UsersView import UsersView
+from .PersonasView import PersonasView

--- a/backend/managers/PersonasManager.py
+++ b/backend/managers/PersonasManager.py
@@ -1,0 +1,102 @@
+from uuid import uuid4
+from threading import Lock
+from sqlalchemy import select, insert, update, delete, func
+from backend.models import Persona
+from backend.db import db_session_context
+from backend.schemas import PersonaSchema, PersonaCreateSchema
+from typing import List, Tuple, Optional, Dict, Any
+
+class PersonasManager:
+    _instance = None
+    _lock = Lock()
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            with cls._lock:
+                if not cls._instance:
+                    cls._instance = super(PersonasManager, cls).__new__(cls, *args, **kwargs)
+        return cls._instance
+
+    def __init__(self):
+        if not hasattr(self, '_initialized'):
+            with self._lock:
+                if not hasattr(self, '_initialized'):
+                    self._initialized = True
+
+    async def create_persona(self, persona_data: PersonaCreateSchema) -> str:
+        async with db_session_context() as session:
+            new_persona = Persona(id=str(uuid4()), **persona_data)
+            session.add(new_persona)
+            await session.commit() 
+            await session.refresh(new_persona)
+            return new_persona.id    
+
+    async def update_persona(self, id: str, persona_data: PersonaCreateSchema) -> Optional[PersonaSchema]:
+        async with db_session_context() as session:
+            stmt = update(Persona).where(Persona.id == id).values(**persona_data)
+            result = await session.execute(stmt)
+            if result.rowcount > 0:
+                await session.commit()
+                updated_persona = await session.get(Persona, id)
+                return PersonaSchema(id=updated_persona.id, **persona_data)
+            return None
+
+    async def delete_persona(self, id) -> bool:
+        async with db_session_context() as session:
+            stmt = delete(Persona).where(Persona.id == id)
+            result = await session.execute(stmt)
+            await session.commit()
+            return result.rowcount > 0
+
+    async def retrieve_persona(self, id:str) -> Optional[PersonaSchema]:
+        async with db_session_context() as session:            
+            result = await session.execute(select(Persona).filter(Persona.id == id))
+            persona = result.scalar_one_or_none()
+            if persona:
+                return PersonaSchema(
+                    id=persona.id,
+                    name=persona.name,
+                    description=persona.description,
+                    voice_id=persona.voice_id,
+                    face_id=persona.face_id                    
+                )
+            return None
+
+    async def retrieve_personas(self, offset: int = 0, limit: int = 100, sort_by: Optional[str] = None,
+                                sort_order:str = 'asc',  filters: Optional[Dict[str, Any]] = None) -> Tuple[List[PersonaSchema], int]:
+        async with db_session_context() as session:
+            query = select(Persona)
+
+            if filters:
+                for key, value in filters.items():
+                    if key == 'name':
+                        query = query.filter(Persona.name.ilike(f"%{value}%"))
+                    elif isinstance(value, list):
+                        query = query.filter(getattr(Persona, key).in_(value))
+                    else:
+                        query = query.filter(getattr(Persona, key) == value)
+
+            if sort_by and sort_by in ['id', 'name', 'description', 'voice_id', 'face_id']:
+                order_column = getattr(Persona, sort_by)
+                query = query.order_by(order_column.desc() if sort_order.lower() == 'desc' else order_column)
+
+            query = query.offset(offset).limit(limit)
+
+            result = await session.execute(query)
+            personas = [PersonaSchema.from_orm(persona) for persona in result.scalars().all()]
+
+            # Get total count
+            count_query = select(func.count()).select_from(Persona)
+            if filters:
+                for key, value in filters.items():
+                    if key == 'name':
+                        count_query = count_query.filter(Persona.name.ilike(f"%{value}%"))
+                    elif isinstance(value, list):
+                        count_query = count_query.filter(getattr(Persona, key).in_(value))
+                    else:
+                        count_query = count_query.filter(getattr(Persona, key) == value)
+
+            total_count = await session.execute(count_query)
+            total_count = total_count.scalar()
+
+            return personas, total_count

--- a/backend/managers/__init__.py
+++ b/backend/managers/__init__.py
@@ -4,6 +4,7 @@ from .ChannelsManager import ChannelsManager
 from .ConfigManager import ConfigManager
 from .DownloadsManager import DownloadsManager
 from .UsersManager import UsersManager
+from .PersonasManager import PersonasManager
 
 # List of manager classes
 manager_classes = [
@@ -12,7 +13,8 @@ manager_classes = [
     ChannelsManager,
     ConfigManager,
     DownloadsManager,
-    UsersManager
+    UsersManager,
+    PersonasManager
 ]
 
 # Initialize the managers dynamically

--- a/backend/models.py
+++ b/backend/models.py
@@ -25,4 +25,12 @@ class Asset(Base):
     title = Column(String, nullable=False)
     creator = Column(String, nullable=True)
     subject = Column(String, nullable=True)
+    description = Column(String, nullable=True)    
+
+class Persona(Base):
+    __tablename__ = "persona"
+    id = Column(String, primary_key=True)
+    name = Column(String, nullable=False)
     description = Column(String, nullable=True)
+    voice_id = Column(String, nullable=True)
+    face_id = Column(String, nullable=True)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 from typing import Optional
 
+
 # We have *Create schemas because API clients ideally don't set the id field, it's set by the server
 # Alternatively we could have made the id optional but then we would have to check if it's set by the client
 
@@ -20,6 +21,22 @@ class ChannelCreateSchema(ChannelBaseSchema):
     pass
 
 class ChannelSchema(ChannelBaseSchema):
+    id: str
+
+# Persona schemas
+class PersonaBaseSchema(BaseModel):
+    name: str
+    description: Optional[str] = None
+    voice_id: str = None
+    face_id: str = None
+    class Config:
+        orm_mode = True
+        from_attributes = True
+
+class PersonaCreateSchema(PersonaBaseSchema):
+    pass
+
+class PersonaSchema(PersonaBaseSchema):
     id: str
 
 # User schemas

--- a/migrations/versions/f5235ab5e888_added_persona_table.py
+++ b/migrations/versions/f5235ab5e888_added_persona_table.py
@@ -1,0 +1,39 @@
+"""added persona table
+
+Revision ID: f5235ab5e888
+Revises: cb6e97a5186c
+Create Date: 2024-07-16 15:43:22.600859
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+# revision identifiers, used by Alembic.
+revision: str = 'f5235ab5e888'
+down_revision: Union[str, None] = 'cb6e97a5186c'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Check if the persona table already exists
+    conn = op.get_bind()
+    if not conn.dialect.has_table(conn, 'persona'):
+        # Create the persona table if it doesn't exist
+        op.create_table(
+            'persona',
+            sa.Column('id',  sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+            sa.Column('name',  sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+            sa.Column('description', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+            sa.Column('voice_id',  sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+            sa.Column('face_id',  sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+            sa.PrimaryKeyConstraint('id')
+        )
+
+def downgrade() -> None:
+    # Drop the persona table if it exists
+    conn = op.get_bind()
+    if conn.dialect.has_table(conn, 'persona'):
+        op.drop_table('persona')


### PR DESCRIPTION
# Summary
This PR modifies the object Persona and PersonaCreate, changing the fields voiceId to Voice object and faceId to Face object

 
# Changes
- [x] Modified Persona
- [x] Modified PersonaCreate

 
# Related Issues
N/A
 
# Type of Change
This change solved the comments posted on the review of the previous PR created by @rquesada [https://github.com/pAI-OS/paios/pull/4]
 
# Checklist 
- [x] I have read the [CONTRIBUTING](https://github.com/pAI-OS/paios/blob/main/CONTRIBUTING.md) documentation.
- [x]  I have performed a self-review of my own code.
- [x]  I have added tests that prove my fix is effective or that my feature works.
- [x]  I have updated the documentation (if applicable).
 
# Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/02e7d59c-c4a3-41e9-b0fb-4558fe0a2187)
![Screenshot 2024-08-07 at 1 32 40 PM](https://github.com/user-attachments/assets/88f878f6-8bf8-4ed9-bf8e-a1062ffd377f)
![image](https://github.com/user-attachments/assets/566ebfdd-8f03-4e3c-9cfa-19caf7d9e060)
 
 
# Additional Context
Tested locally using Swagger.
Based on the premise that we are not expecting that faces and voices to be modified frequently, so  the approach we considered here was to create an "assets" folder (in the front-end) to store the images, videos and audios. Then it was only going to be necessary to store the id of voice and face to help us associate the asset with the voice and face.

For example:
Given the object Persona:
```
      {
        "name": "Mari",
        "description": "Mari A",
        "voice_id": "x4te5a69-40d6-4246-8d53-f4c777be8080",
        "face_id": "7ffe5a69-40d6-4246-8d54-f4c777be6989",
        "id": "91a7542f-da52-46ab-85b9-08f871722e93"
      }
```
The frontend will be able to load the files:
      :/assests/audio/x4te5a69-40d6-4246-8d53-f4c777be8080.mp3
      :/assests/face/7ffe5a69-40d6-4246-8d54-f4c777be6989.jpg
      :/assests/video/7ffe5a69-40d6-4246-8d54-f4c777be6989.mp4