### PR TITLE
Fix: required_version not work in PythonDependency

### DIFF
--- a/backend/dependencies/PythonDependency.py
+++ b/backend/dependencies/PythonDependency.py
@@ -23,9 +23,8 @@ class PythonDependency(Dependency):
     def refresh_status(self, ability, dependency):
         try:
             package_name = dependency.get('id')
-            required_version = dependency.get('required', '')
-
             versions = dependency.get('versions', {})
+            required_version = versions.get('required', '')
 
             self._refresh_versions(package_name, required_version, versions)
 


### PR DESCRIPTION
# Summary
This PR includes the following fixes
 
* Malfunctioning required_version in the PythonDependency

required_version was always blank cuz it was mistakenly got from dependency, which was the wrong location in the metadata.json. Fix it to fetch it from dependency.versions

# Changes
* [x]  Updated PythonDependency to fetch rquired_version from versions of dependency

# Related Issues
N/A
 
# Type of Change
Bug fix
 
# Checklist
* [x]  I have read the [CONTRIBUTING](https://github.com/pAI-OS/paios/blob/main/CONTRIBUTING.md) documentation.
* [x]   I have performed a self-review of my own code.
* [x]   I have added tests that prove my fix is effective or that my feature works.
* [x]   I have updated the documentation (if applicable)

# Screenshots (if applicable) Example of use:

<img width="1805" alt="image" src="https://github.com/user-attachments/assets/a3fbac34-58f9-4115-a439-7cfe4615e047">
<img width="646" alt="image" src="https://github.com/user-attachments/assets/3d35dab7-34bd-41de-acb8-f267656d2371">


