### PR TITLE
fix Share key format in OpenAPI schema to reflect implementation

### DIFF
--- a/apis/paios/openapi.yaml
+++ b/apis/paios/openapi.yaml
@@ -884,13 +884,13 @@ components:
       pattern: ^[a-z0-9]+:[a-f0-9]{1,128}$
     shortUrlKey:
       type: string
-      example: abc-def-ghi
-      pattern: ^[a-z]{3}-[a-z]{3}-[a-z]{3}$
+      example: abcd-efgh-ijkl
+      pattern: ^[a-z]{4}-[a-z]{4}-[a-z]{4}$
     shortUrlKeyReadOnly:
       type: string
       readOnly: true
-      example: abc-def-ghi
-      pattern: ^[a-z]{3}-[a-z]{3}-[a-z]{3}$
+      example: abcd-efgh-ijkl
+      pattern: ^[a-z]{4}-[a-z]{4}-[a-z]{4}$
     download:
       type: object
       properties:

--- a/backend/models.py
+++ b/backend/models.py
@@ -32,7 +32,7 @@ class Persona(SQLModelBase, table=True):
     face_id: str | None = Field(default=None)
 
 class Share(SQLModelBase, table=True):
-    id: str = Field(primary_key=True)  # the short URL tag, eg abc-def-ghi
+    id: str = Field(primary_key=True)  # the short URL tag, eg abcd-efgh-ijkl
     resource_id: str = Field(foreign_key="resource.id")  # the bot ID
     user_id: str | None = Field(default=None)  # the user granted access (optional)
     expiration_dt: datetime | None = Field(default=None)  # the link expiration date/time (optional)


### PR DESCRIPTION
**Bug fix**:  updated the schema definitions for shortUrlKey and shortUrlKeyReadOnly in the openapi.yaml file to reflect the latest implementation.  (Corrected to reflect the "abcd-efgh-ijkl" format)