### PR TITLE
LiteLLM integration

### DIFF
--- a/apis/paios/openapi.yaml
+++ b/apis/paios/openapi.yaml
@@ -1499,7 +1499,7 @@ components:
           type: string
         name:
           type: string
-        llm_name:
+        full_name:
           type: string
         provider:
           type: string
@@ -1511,6 +1511,7 @@ components:
       required:
         - id
         - name
+        - full_name
         - provider
         - is_active
     RegistrationOptions:

--- a/apis/paios/openapi.yaml
+++ b/apis/paios/openapi.yaml
@@ -789,6 +789,8 @@ paths:
           description: Not Found
   /llms:
     get:
+      security:
+        - jwt: []
       tags:
         - LLM Management
       summary: Retrieve all available LLMs
@@ -811,6 +813,8 @@ paths:
               $ref: '#/components/headers/X-Total-Count'
   '/llms/{id}':
     get:
+      security:
+        - jwt: []
       tags:
         - LLM Management
       summary: Retrieve LLM by id
@@ -828,6 +832,8 @@ paths:
           description: LLM not found
   '/llms/{id}/completion':
     post:
+      security:
+        - jwt: []
       tags:
         - LLM Management
       summary: Invoke Completion on LLM

--- a/apis/paios/openapi.yaml
+++ b/apis/paios/openapi.yaml
@@ -844,6 +844,10 @@ paths:
               properties:
                 messages:
                   $ref: '#/components/schemas/messagesList'
+                optional_params:
+                  $ref: '#/components/schemas/completionParamList'
+              required:
+                - messages              
       responses:
         '200':
           description: Completion succeeded
@@ -979,6 +983,8 @@ tags:
     description: Management of personas
   - name: Share Management
     description: Management of share links
+  - name: LLM Management
+    description: Discovery and invocation of LLM functionality
 components:
   securitySchemes:
     jwt:
@@ -1169,6 +1175,9 @@ components:
             type: string
           content:
             type: string
+    completionParamList:
+      type: object
+      example: {"max_tokens": 50, "temperature": 0.2}
     download:
       type: object
       properties:

--- a/apis/paios/openapi.yaml
+++ b/apis/paios/openapi.yaml
@@ -700,6 +700,8 @@ paths:
       - $ref: '#/components/parameters/id'  
   /shares:
     get:
+      security:
+        - jwt: []
       tags:
         - Share Management
       summary: Retrieve all share links
@@ -721,6 +723,8 @@ paths:
             X-Total-Count:
               $ref: '#/components/headers/X-Total-Count'
     post:
+      security:
+        - jwt: []
       summary: Create new share link
       tags:
         - Share Management
@@ -737,6 +741,8 @@ paths:
               $ref: '#/components/schemas/ShareCreate'
   '/shares/{id}':
     get:
+      security:
+        - jwt: []
       tags:
         - Share Management
       summary: Retrieve share link by id
@@ -751,6 +757,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Share'
     put:
+      security:
+        - jwt: []
       tags:
         - Share Management
       summary: Update share link by id
@@ -766,6 +774,8 @@ paths:
         '200':
           description: OK
     delete:
+      security:
+        - jwt: []
       tags:
         - Share Management
       summary: Delete share link by id
@@ -777,6 +787,74 @@ paths:
           description: No Content
         '404':
           description: Not Found
+  /llms:
+    get:
+      tags:
+        - LLM Management
+      summary: Retrieve all available LLMs
+      description: Get all installed / available LLMs.
+      parameters:
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/range'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Llm'
+          headers:
+            X-Total-Count:
+              $ref: '#/components/headers/X-Total-Count'
+  '/llms/{id}':
+    get:
+      tags:
+        - LLM Management
+      summary: Retrieve LLM by id
+      description: Retrieve the LLM with the specified id.
+      parameters:
+        - $ref: '#/components/parameters/kebab-dot_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Llm'
+        '404':
+          description: LLM not found
+  '/llms/{id}/completion':
+    post:
+      tags:
+        - LLM Management
+      summary: Invoke Completion on LLM
+      description: Invoke Completion on the LLM with the specified id.
+      operationId: backend.api.LlmsView.completion
+      parameters:
+        - $ref: '#/components/parameters/kebab-dot_id'
+      requestBody:
+        description: Messages to input to Completion function.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                messages:
+                  $ref: '#/components/schemas/messagesList'
+      responses:
+        '200':
+          description: Completion succeeded
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Completion failed
+        '404':
+          description: LLM not found
   /auth/webauthn/register-options:
     post:
       summary: Generate WebAuthn registration options
@@ -936,6 +1014,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/kebab-snake_id'
+    kebab-dot_id:
+      name: id
+      in: path
+      description: id of the object
+      required: true
+      schema:
+        $ref: '#/components/schemas/kebab-dot_id'
     key:
       name: key
       in: path
@@ -1003,6 +1088,12 @@ components:
       maxLength: 100
       example: langchain-core
       pattern: ^[a-z0-9]+([_-][a-z0-9]+)*$
+    kebab-dot_id:
+      type: string
+      minLength: 2
+      maxLength: 100
+      example: ollama-llama3.2
+      pattern: ^[a-z0-9]+([.-][a-z0-9]+)*$
     semVer:
       type: string
       example: '1.1.0'
@@ -1068,6 +1159,16 @@ components:
       readOnly: true
       example: abcd-efgh-ijkl
       pattern: ^[a-z]{4}-[a-z]{4}-[a-z]{4}$
+    messagesList:
+      type: array
+      example: [{"role": "user", "content": "What is Kwaai.ai?"}]
+      items:
+        type: object
+        properties:
+          role:
+            type: string
+          content:
+            type: string
     download:
       type: object
       properties:
@@ -1390,6 +1491,28 @@ components:
           example: false
       required:        
         - resource_id
+    Llm:
+      type: object
+      title: Llm
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        llm_name:
+          type: string
+        provider:
+          type: string
+        api_base:
+          type: string
+          nullable: true
+        is_active:
+          type: boolean
+      required:
+        - id
+        - name
+        - provider
+        - is_active
     RegistrationOptions:
       type: object
       properties:

--- a/backend/api/LlmsView.py
+++ b/backend/api/LlmsView.py
@@ -1,15 +1,15 @@
 from starlette.responses import JSONResponse
-from backend.managers.LlmsManager import LlmsManager
+from backend.managers.ModelsManager import ModelsManager
 from backend.pagination import parse_pagination_params
 from backend.schemas import LlmSchema
 from litellm.exceptions import BadRequestError
 
 class LlmsView:
     def __init__(self):
-        self.llmm = LlmsManager()
+        self.mm = ModelsManager()
 
     async def get(self, id: str):
-        llm = await self.llmm.get_llm(id)
+        llm = await self.mm.get_llm(id)
         if llm is None:
             return JSONResponse(headers={"error": "LLM not found"}, status_code=404)
         llm_schema = LlmSchema(id=llm.id, name=llm.name, full_name=f"{llm.provider}/{llm.name}",
@@ -23,7 +23,7 @@ class LlmsView:
 
         offset, limit, sort_by, sort_order, filters = result
 
-        llms, total_count = await self.llmm.retrieve_llms(limit=limit, offset=offset, sort_by=sort_by, sort_order=sort_order, filters=filters)
+        llms, total_count = await self.mm.retrieve_llms(limit=limit, offset=offset, sort_by=sort_by, sort_order=sort_order, filters=filters)
         results = [LlmSchema(id=llm.id, name=llm.name, full_name=f"{llm.provider}/{llm.name}",
                              provider=llm.provider, api_base=llm.api_base,
                              is_active=llm.is_active)
@@ -36,7 +36,7 @@ class LlmsView:
 
     async def completion(self, id: str, body: dict):
         print("completion.  body: {}".format(body))
-        llm = await self.llmm.get_llm(id)
+        llm = await self.mm.get_llm(id)
         if llm:
             messages = []
             if 'messages' in body and body['messages']:
@@ -45,7 +45,7 @@ class LlmsView:
             if 'optional_params' in body and body['optional_params']:
                 opt_params = body['optional_params']
             try:
-                response = self.llmm.completion(llm, messages, **opt_params)
+                response = self.mm.completion(llm, messages, **opt_params)
                 return JSONResponse(response.model_dump(), status_code=200)
             except BadRequestError as e:
                 return JSONResponse(status_code=400, content={"message": e.message})

--- a/backend/api/LlmsView.py
+++ b/backend/api/LlmsView.py
@@ -1,0 +1,43 @@
+from starlette.responses import JSONResponse
+from backend.managers.LlmsManager import LlmsManager
+from backend.pagination import parse_pagination_params
+
+class LlmsView:
+    def __init__(self):
+        self.llmm = LlmsManager()
+
+    async def get(self, id: str):
+        llm = await self.llmm.get_llm(id)
+        if llm is None:
+            return JSONResponse(headers={"error": "LLM not found"}, status_code=404)
+        return JSONResponse(llm.model_dump(), status_code=200)
+
+    async def search(self, filter: str = None, range: str = None, sort: str = None):
+        result = parse_pagination_params(filter, range, sort)
+        if isinstance(result, JSONResponse):
+            return result
+
+        offset, limit, sort_by, sort_order, filters = result
+
+        llms, total_count = await self.llmm.retrieve_llms(limit=limit, offset=offset, sort_by=sort_by, sort_order=sort_order, filters=filters)
+        headers = {
+            'X-Total-Count': str(total_count),
+            'Content-Range': f'shares {offset}-{offset + len(llms) - 1}/{total_count}'
+        }
+        return JSONResponse([llm.model_dump() for llm in llms], status_code=200, headers=headers)
+
+    async def completion(self, id: str, body: dict):
+        print("completion.  body: {}".format(body))
+        messages = []
+        if 'messages' in body and body['messages']:
+            messages = body['messages']
+        llm = await self.llmm.get_llm(id)
+        if llm:
+            print("Selected LLM is {}".format(llm.llm_name))
+            response = self.llmm.completion(llm, messages)
+            if response:
+                return JSONResponse(response.model_dump(), status_code=200)
+            else:
+                return JSONResponse(status_code=400, content={"message": "Completion failed"})
+        else:
+            return JSONResponse(status_code=404, content={"message": "LLM not found"})

--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -9,3 +9,4 @@ from .UsersView import UsersView
 from .PersonasView import PersonasView
 from .SharesView import SharesView
 from .AuthView import AuthView
+from .LlmsView import LlmsView

--- a/backend/managers/LlmsManager.py
+++ b/backend/managers/LlmsManager.py
@@ -123,7 +123,7 @@ class LlmsManager:
 
     async def _load_ollama_models(self):
         try:
-            ollama_urlroot = get_env_key("OLLAMA_URLROOT", "http://localhost:11434")
+            ollama_urlroot = get_env_key("OLLAMA_URLROOT")
         except ValueError:
             print("No Ollama server specified.  Skipping.")
             return  # no Ollama server specified, skip

--- a/backend/managers/LlmsManager.py
+++ b/backend/managers/LlmsManager.py
@@ -1,0 +1,167 @@
+import asyncio
+import httpx
+from threading import Lock
+from sqlalchemy import select, insert, update, delete, func
+from backend.models import Llm
+from backend.db import db_session_context
+from backend.schemas import LlmSchema
+from backend.utils import get_env_key
+from typing import List, Tuple, Optional, Dict, Any, Union
+from litellm import Router
+from litellm.utils import CustomStreamWrapper, ModelResponse
+
+import logging
+logger = logging.getLogger(__name__)
+
+class LlmsManager:
+    _instance = None
+    _lock = Lock()
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            with cls._lock:
+                if not cls._instance:
+                    cls._instance = super(LlmsManager, cls).__new__(cls, *args, **kwargs)
+        return cls._instance
+
+    def __init__(self):
+        if not hasattr(self, '_initialized'):  # Ensure initialization happens only once
+            with self._lock:
+                if not hasattr(self, '_initialized'):
+                    self.router = None
+                    router_init_task = asyncio.create_task(self._init_router())
+                    asyncio.gather(router_init_task, return_exceptions=True)
+                    self._initialized = True
+
+    async def _init_router(self):
+        try:
+            # load models
+            ollama_task = asyncio.create_task(self._load_ollama_models())
+            await asyncio.gather(ollama_task, return_exceptions=True)
+            # collect the available LLMs
+            llms, total_llms = await self.retrieve_llms()
+            # configure router
+            model_list = []
+            for llm in llms:
+                params = {}
+                params["model"] = llm.llm_name
+                if llm.provider == "ollama":
+                    params["api_base"] = llm.api_base
+                model = {
+                    "model_name": llm.llm_name,
+                    "litellm_params": params,
+                }
+                model_list.append(model)
+            print(model_list)
+            self.router = Router(model_list=model_list)
+        except Exception as e:
+            logger.exception(e)
+
+    async def _load_ollama_models(self):
+        try:
+            ollama_urlroot = get_env_key("OLLAMA_URLROOT")  # eg: http://localhost:11434
+        except ValueError:
+            return  # no Ollama server specified
+        # retrieve list of installed models
+        async with httpx.AsyncClient() as client:
+            response = await client.get("{}/api/tags".format(ollama_urlroot))
+            if response.status_code == 200:
+                data = response.json()
+                available_models = [model_data['model'] for model_data in data.get("models", [])]
+                print(available_models)      
+            else:
+                pass # FIX
+        # create / update Ollama family Llm objects
+        provider = "ollama"
+        async with db_session_context() as session:
+            # mark existing models as inactive
+            stmt = update(Llm).where(Llm.provider == provider).values(is_active=False)
+            result = await session.execute(stmt)
+            if result.rowcount > 0:
+                await session.commit()
+            # insert / update models
+            for model in available_models:
+                name = model.removesuffix(":latest")
+                llm_name = "{}/{}".format(provider,name)  # what LiteLLM expects
+                safe_name = llm_name.replace("/", "-").replace(":", "-")
+                result = await session.execute(select(Llm).filter(Llm.id == safe_name))
+                llm = result.scalar_one_or_none()
+                if llm:
+                    stmt = update(Llm).where(Llm.id == safe_name).values(name=name,
+                                                                         llm_name=llm_name,
+                                                                         provider=provider,
+                                                                         api_base=ollama_urlroot,
+                                                                         is_active=True)
+                    result = await session.execute(stmt)
+                    if result.rowcount > 0:
+                        await session.commit()
+                else:
+                    new_llm = Llm(id=safe_name, name=name, llm_name=llm_name,
+                                  provider=provider, api_base=ollama_urlroot,
+                                  is_active=True)
+                    session.add(new_llm)
+                    await session.commit()
+
+    async def get_llm(self, id: str) -> Optional[LlmSchema]:
+        async with db_session_context() as session:
+            result = await session.execute(select(Llm).filter(Llm.id == id))
+            llm = result.scalar_one_or_none()
+            if llm:
+                return LlmSchema(id=llm.id, name=llm.name, llm_name=llm.llm_name,
+                                 provider=llm.provider, api_base=llm.api_base, is_active=llm.is_active)
+            return None
+
+    async def retrieve_llms(self, offset: int = 0, limit: int = 100, sort_by: Optional[str] = None,
+                            sort_order: str = 'asc', filters: Optional[Dict[str, Any]] = None) -> Tuple[List[LlmSchema], int]:
+        async with db_session_context() as session:
+            query = select(Llm).filter(Llm.is_active == True)
+
+            if filters:
+                for key, value in filters.items():
+                    if isinstance(value, list):
+                        query = query.filter(getattr(Llm, key).in_(value))
+                    else:
+                        query = query.filter(getattr(Llm, key) == value)
+
+            if sort_by and sort_by in ['id', 'name', 'llm_name', 'provider', 'api_base', 'is_active']:
+                order_column = getattr(Llm, sort_by)
+                query = query.order_by(order_column.desc() if sort_order.lower() == 'desc' else order_column)
+
+            query = query.offset(offset).limit(limit)
+
+            result = await session.execute(query)
+            llms = [LlmSchema(id=llm.id, name=llm.name, llm_name=llm.llm_name,
+                              provider=llm.provider, api_base=llm.api_base,
+                              is_active=llm.is_active) 
+                        for llm in result.scalars().all()]
+
+            # Get total count
+            count_query = select(func.count()).select_from(Llm).filter(Llm.is_active == True)
+            if filters:
+                for key, value in filters.items():
+                    if isinstance(value, list):
+                        count_query = count_query.filter(getattr(Llm, key).in_(value))
+                    else:
+                        count_query = count_query.filter(getattr(Llm, key) == value)
+
+            total_count = await session.execute(count_query)
+            total_count = total_count.scalar()
+
+            return llms, total_count
+
+    def completion(self, llm, messages, **optional_params) -> Union[ModelResponse, CustomStreamWrapper]:
+        response = self.router.completion(model=llm.llm_name,
+                                          messages=messages,
+                                          kwargs=optional_params)
+        print("completion response: {}".format(response))
+        #message = response.choices[0].message.content
+        #return message
+        return response
+
+    async def acompletion(self, llm, messages, **optional_params) -> Union[CustomStreamWrapper, ModelResponse]:
+        response = await self.router.acompletion(model=llm.llm_name,
+                                                 messages=messages,
+                                                 kwargs=optional_params)
+        print("acompletion response: {}".format(response))
+        return response
+    

--- a/backend/managers/ModelsManager.py
+++ b/backend/managers/ModelsManager.py
@@ -12,7 +12,7 @@ from litellm.utils import CustomStreamWrapper, ModelResponse
 import logging
 logger = logging.getLogger(__name__)
 
-class LlmsManager:
+class ModelsManager:
     _instance = None
     _lock = Lock()
 
@@ -20,7 +20,7 @@ class LlmsManager:
         if not cls._instance:
             with cls._lock:
                 if not cls._instance:
-                    cls._instance = super(LlmsManager, cls).__new__(cls, *args, **kwargs)
+                    cls._instance = super(ModelsManager, cls).__new__(cls, *args, **kwargs)
         return cls._instance
 
     def __init__(self):
@@ -80,7 +80,7 @@ class LlmsManager:
             response = self.router.completion(model=llm.llm_name,
                                               messages=messages,
                                               **optional_params)
-            # below is the direct way to call the LLM (i.e. not using the router):
+            # below is the direct way to call the model (i.e. not using the router):
             #response = completion(model=llm.llm_name,
             #                      messages=messages,
             #                      **optional_params)
@@ -98,7 +98,7 @@ class LlmsManager:
             await asyncio.gather(ollama_task,
                                  openai_task,
                                  return_exceptions=True)
-            # collect the available LLMs
+            # collect the available models
             llms, total_llms = await self.retrieve_llms()
             # configure router
             model_list = []

--- a/backend/models.py
+++ b/backend/models.py
@@ -65,6 +65,14 @@ class Share(SQLModelBase, table=True):
     expiration_dt: datetime | None = Field(default=None)  # the link expiration date/time (optional)
     is_revoked: bool = Field()
 
+class Llm(SQLModelBase, table=True):
+    id: str = Field(primary_key=True)  # the model's unique, URL-friendly name
+    name: str = Field()
+    llm_name: str = Field()  # the model name known to LiteLLM
+    provider: str = Field()  # model provider, eg "ollama"
+    api_base: str | None = Field(default=None)
+    is_active: bool = Field()  # is the model installed / available?
+
 # Resolve forward references
 User.model_rebuild()
 Cred.model_rebuild()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,3 +20,4 @@ structlog
 webauthn
 greenlet
 pyjwt
+litellm

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -88,6 +88,14 @@ class ShareCreateSchema(ShareBaseSchema):
 class ShareSchema(ShareBaseSchema):
     id: str
 
+class LlmSchema(BaseModel):
+    id: str
+    name: str
+    llm_name: str
+    provider: str
+    api_base: Optional[str] = None
+    is_active: bool
+
 class RegistrationOptions(BaseModel):
     email: str
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -91,7 +91,7 @@ class ShareSchema(ShareBaseSchema):
 class LlmSchema(BaseModel):
     id: str
     name: str
-    llm_name: str
+    full_name: str
     provider: str
     api_base: Optional[str] = None
     is_active: bool

--- a/migrations/versions/73d50424c826_added_llm_table.py
+++ b/migrations/versions/73d50424c826_added_llm_table.py
@@ -1,0 +1,35 @@
+"""added llm table
+
+Revision ID: 73d50424c826
+Revises: 187855982332
+Create Date: 2024-10-10 17:31:43.949960
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = '73d50424c826'
+down_revision: Union[str, None] = '187855982332'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table('llm',
+    sa.Column('id', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+    sa.Column('name', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+    sa.Column('llm_name', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+    sa.Column('provider', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+    sa.Column('api_base', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    sa.Column('is_active', sa.Boolean(), nullable=False),
+    sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('llm')


### PR DESCRIPTION
Integrated LiteLLM into paios to facilitate the interaction with the LLMs of various providers using a standard interface.

- introduced Llm model
- introduced ModelsManager, that initializes and uses the LiteLLM router to interact with models from different providers (_at present time, only Ollama and OpenAI models are loaded during the ModelsManager's initialization_)
- implemented Llm-related API endpoints:
    - get-all
    - get
    - completion, which accepts the OpenAI-style parameters as well as provider-specific parameters